### PR TITLE
Fixing typo

### DIFF
--- a/docs/cloudnative.adoc
+++ b/docs/cloudnative.adoc
@@ -351,7 +351,7 @@ We also need to update the functional test to reflect the changes made to endpoi
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/greeting")
+          .when().get("/hello")
           .then()
              .statusCode(200)
              .body(is("hello quarkus!")); // Modified line


### PR DESCRIPTION
There was a typo in the `testHelloEndpoint` test - it was getting the `/greeting` endpoint instead of `/hello`.